### PR TITLE
Add CUDA support for BGE-M3 inference

### DIFF
--- a/samples/dotnet/BgeM3.Onnx.Tests/BgeM3EmbeddingComparisonTests.cs
+++ b/samples/dotnet/BgeM3.Onnx.Tests/BgeM3EmbeddingComparisonTests.cs
@@ -135,7 +135,7 @@ public sealed class BgeM3EmbeddingComparisonTests : IDisposable
         return dotProduct / (Math.Sqrt(normA) * Math.Sqrt(normB));
     }
 
-    private bool AreSparseWeightsEqual(Dictionary<int, float> csharpWeights, Dictionary<int, float> pythonWeights)
+    private static bool AreSparseWeightsEqual(Dictionary<int, float> csharpWeights, Dictionary<int, float> pythonWeights)
     {
         if (csharpWeights.Count != pythonWeights.Count)
         {

--- a/samples/dotnet/BgeM3.Onnx/BgeM3.Onnx.csproj
+++ b/samples/dotnet/BgeM3.Onnx/BgeM3.Onnx.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Extensions" Version="0.14.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/dotnet/BgeM3.Onnx/ExecutionProvider.cs
+++ b/samples/dotnet/BgeM3.Onnx/ExecutionProvider.cs
@@ -1,0 +1,17 @@
+﻿namespace BgeM3.Onnx;
+
+/// <summary>
+/// Supported execution providers for ONNX inference
+/// </summary>
+public enum ExecutionProvider
+{
+    /// <summary>
+    /// CPU execution provider (default, always available)
+    /// </summary>
+    CPU,
+
+    /// <summary>
+    /// CUDA execution provider (requires CUDA-enabled GPU and CUDA runtime)
+    /// </summary>
+    CUDA
+}

--- a/samples/dotnet/BgeM3.Onnx/M3Embedder.cs
+++ b/samples/dotnet/BgeM3.Onnx/M3Embedder.cs
@@ -4,29 +4,113 @@ using Microsoft.ML.OnnxRuntime.Tensors;
 namespace BgeM3.Onnx;
 
 /// <summary>
-/// Provides functionality to generate embeddings using ONNX bge-m3 model
+/// Provides functionality to generate embeddings using ONNX bge-m3 model with multi-provider support
 /// </summary>
 public class M3Embedder : IDisposable
 {
     private readonly InferenceSession _tokenizerSession;
     private readonly InferenceSession _modelSession;
     private readonly HashSet<int> _specialTokenIds = [0, 1, 2, 3]; // [PAD], [UNK], [CLS], [SEP]
+    private readonly M3EmbedderConfig _config;
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new instance of the M3Embedder class
+    /// Gets the configuration used by this embedder
+    /// </summary>
+    public M3EmbedderConfig Config => _config;
+
+    /// <summary>
+    /// Initializes a new instance of the M3Embedder class with default CPU provider
     /// </summary>
     /// <param name="tokenizerPath">Path to the ONNX tokenizer model</param>
     /// <param name="modelPath">Path to the ONNX embedding model</param>
-    public M3Embedder(string tokenizerPath, string modelPath)
+    public M3Embedder(string tokenizerPath, string modelPath) : this(tokenizerPath, modelPath, new M3EmbedderConfig()) { }
+
+    /// <summary>
+    /// Initializes a new instance of the M3Embedder class with specified configuration
+    /// </summary>
+    /// <param name="tokenizerPath">Path to the ONNX tokenizer model</param>
+    /// <param name="modelPath">Path to the ONNX embedding model</param>
+    /// <param name="config">Configuration for execution providers and other options</param>
+    public M3Embedder(string tokenizerPath, string modelPath, M3EmbedderConfig config)
     {
-        // Initialize tokenizer session with ONNX Extensions
-        using var tokenizerOptions = new SessionOptions();
+        _config = config ?? new M3EmbedderConfig();
+
+        // Initialize tokenizer session with ONNX Extensions (CPU-only)
+        var tokenizerOptions = CreateSessionOptions(forTokenizer: true);
         tokenizerOptions.RegisterOrtExtensions();
         _tokenizerSession = new InferenceSession(tokenizerPath, tokenizerOptions);
 
-        // Initialize model session
-        _modelSession = new InferenceSession(modelPath);
+        // Initialize model session with specified execution provider
+        var modelOptions = CreateSessionOptions(forTokenizer: false);
+        _modelSession = new InferenceSession(modelPath, modelOptions);
+    }
+
+    /// <summary>
+    /// Creates session options with appropriate execution providers
+    /// </summary>
+    private SessionOptions CreateSessionOptions(bool forTokenizer)
+    {
+        var sessionOptions = new SessionOptions
+        {
+            EnableMemoryPattern = _config.EnableMemoryPattern,
+            EnableCpuMemArena = _config.EnableCpuMemArena,
+            LogSeverityLevel = _config.LogSeverityLevel
+        };
+
+        // For tokenizer, we use CPU since it involves ONNX Extensions
+        // and string processing which may not be optimized for GPU
+        if (forTokenizer)
+        {
+            return sessionOptions;
+        }
+
+        // For the main model, apply the requested execution providers
+        var providers = GetProviderList();
+
+        foreach (var provider in providers)
+        {
+            switch (provider)
+            {
+                case ExecutionProvider.CUDA:
+                    sessionOptions.AppendExecutionProvider_CUDA(_config.CudaDeviceId);
+                    break;
+
+                case ExecutionProvider.CPU:
+                    // CPU is always available and added by default
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unsupported execution provider: {provider}");
+            }
+        }
+
+        return sessionOptions;
+    }
+
+    /// <summary>
+    /// Gets the list of execution providers to try in order
+    /// </summary>
+    private List<ExecutionProvider> GetProviderList()
+    {
+        var providers = new List<ExecutionProvider> { _config.ExecutionProvider };
+
+        // Add fallback providers if they're different from the primary
+        foreach (var fallback in _config.FallbackProviders)
+        {
+            if (fallback != _config.ExecutionProvider && !providers.Contains(fallback))
+            {
+                providers.Add(fallback);
+            }
+        }
+
+        // Always ensure CPU is available as the final fallback
+        if (!providers.Contains(ExecutionProvider.CPU))
+        {
+            providers.Add(ExecutionProvider.CPU);
+        }
+
+        return providers;
     }
 
     /// <summary>
@@ -134,7 +218,7 @@ public class M3Embedder : IDisposable
     /// <summary>
     /// Extract ColBERT vectors from model output
     /// </summary>
-    private float[][] ExtractColBertVectors(NamedOnnxValue colbertOutput, long[] attentionMask)
+    private static float[][] ExtractColBertVectors(NamedOnnxValue colbertOutput, long[] attentionMask)
     {
         var colbertVectors = new List<float[]>();
         var tensor = colbertOutput.AsTensor<float>();

--- a/samples/dotnet/BgeM3.Onnx/M3Embedder.cs
+++ b/samples/dotnet/BgeM3.Onnx/M3Embedder.cs
@@ -34,7 +34,7 @@ public class M3Embedder : IDisposable
     /// <param name="config">Configuration for execution providers and other options</param>
     public M3Embedder(string tokenizerPath, string modelPath, M3EmbedderConfig config)
     {
-        _config = config ?? new M3EmbedderConfig();
+        _config = config;
 
         // Initialize tokenizer session with ONNX Extensions (CPU-only)
         var tokenizerOptions = CreateSessionOptions(forTokenizer: true);

--- a/samples/dotnet/BgeM3.Onnx/M3EmbedderConfig.cs
+++ b/samples/dotnet/BgeM3.Onnx/M3EmbedderConfig.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.ML.OnnxRuntime;
+
+namespace BgeM3.Onnx;
+
+/// <summary>
+/// Configuration for M3Embedder initialization
+/// </summary>
+public record M3EmbedderConfig
+{
+    /// <summary>
+    /// Primary execution provider to use
+    /// </summary>
+    public ExecutionProvider ExecutionProvider { get; init; } = ExecutionProvider.CPU;
+
+    /// <summary>
+    /// Fallback execution providers in order of preference
+    /// </summary>
+    public ExecutionProvider[] FallbackProviders { get; init; } = [ExecutionProvider.CPU];
+
+    /// <summary>
+    /// CUDA device ID (only used when ExecutionProvider is CUDA)
+    /// </summary>
+    public int CudaDeviceId { get; init; } = 0;
+
+    /// <summary>
+    /// Enable memory pattern optimization
+    /// </summary>
+    public bool EnableMemoryPattern { get; init; } = true;
+
+    /// <summary>
+    /// Enable CPU memory arena
+    /// </summary>
+    public bool EnableCpuMemArena { get; init; } = true;
+
+    /// <summary>
+    /// Log severity level (0=Verbose, 1=Info, 2=Warning, 3=Error, 4=Fatal)
+    /// </summary>
+    public OrtLoggingLevel LogSeverityLevel { get; init; } = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING;
+}

--- a/samples/dotnet/BgeM3.Onnx/M3EmbedderFactory.cs
+++ b/samples/dotnet/BgeM3.Onnx/M3EmbedderFactory.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.ML.OnnxRuntime;
+
+namespace BgeM3.Onnx;
+
+/// <summary>
+/// Factory class for creating M3Embedder instances with common configurations
+/// </summary>
+public static class M3EmbedderFactory
+{
+    /// <summary>
+    /// Creates an M3Embedder optimized for CPU inference
+    /// </summary>
+    /// <param name="tokenizerPath">Path to the ONNX tokenizer model</param>
+    /// <param name="modelPath">Path to the ONNX embedding model</param>
+    /// <returns>M3Embedder configured for CPU</returns>
+    public static M3Embedder CreateCpuOptimized(string tokenizerPath, string modelPath)
+    {
+        var config = new M3EmbedderConfig
+        {
+            ExecutionProvider = ExecutionProvider.CPU,
+            EnableMemoryPattern = true,
+            EnableCpuMemArena = true,
+            LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING
+        };
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+
+    /// <summary>
+    /// Creates an M3Embedder optimized for CUDA inference
+    /// </summary>
+    /// <param name="tokenizerPath">Path to the ONNX tokenizer model</param>
+    /// <param name="modelPath">Path to the ONNX embedding model</param>
+    /// <param name="deviceId">CUDA device ID (default: 0)</param>
+    /// <returns>M3Embedder configured for CUDA</returns>
+    public static M3Embedder CreateCudaOptimized(string tokenizerPath, string modelPath, int deviceId = 0)
+    {
+        var config = new M3EmbedderConfig
+        {
+            ExecutionProvider = ExecutionProvider.CUDA,
+            FallbackProviders = [ExecutionProvider.CPU],
+            CudaDeviceId = deviceId,
+            EnableMemoryPattern = true,
+            EnableCpuMemArena = false, // Disable CPU memory arena when using GPU
+            LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING
+        };
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+
+    /// <summary>
+    /// Creates an M3Embedder with custom configuration
+    /// </summary>
+    /// <param name="tokenizerPath">Path to the ONNX tokenizer model</param>
+    /// <param name="modelPath">Path to the ONNX embedding model</param>
+    /// <param name="primaryProvider">Primary execution provider</param>
+    /// <param name="fallbackProviders">Fallback providers in order of preference</param>
+    /// <param name="cudaDeviceId">CUDA device ID (used only if CUDA is specified)</param>
+    /// <returns>M3Embedder with custom configuration</returns>
+    public static M3Embedder CreateCustom(
+        string tokenizerPath,
+        string modelPath,
+        ExecutionProvider primaryProvider,
+        ExecutionProvider[]? fallbackProviders = null,
+        int cudaDeviceId = 0)
+    {
+        var config = new M3EmbedderConfig
+        {
+            ExecutionProvider = primaryProvider,
+            FallbackProviders = fallbackProviders ?? [ExecutionProvider.CPU],
+            CudaDeviceId = cudaDeviceId,
+            EnableMemoryPattern = true,
+            EnableCpuMemArena = primaryProvider == ExecutionProvider.CPU,
+            LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_WARNING
+        };
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+}

--- a/samples/dotnet/BgeM3.Onnx/Program.cs
+++ b/samples/dotnet/BgeM3.Onnx/Program.cs
@@ -11,49 +11,73 @@ var modelPath = Path.Combine(onnxDir, "bge_m3_model.onnx");
 // Sample text to test with
 string text = "A test text! Texto de prueba! Текст для теста! 測試文字! Testtext! Testez le texte! Сынақ мәтіні! Тестни текст! परीक्षण पाठ! Kiểm tra văn bản!";
 
-Console.WriteLine("===== BGE-M3 ONNX Embedding Research =====");
-Console.WriteLine($"Using tokenizer: {tokenizerPath}");
-Console.WriteLine($"Using model: {modelPath}");
+Console.WriteLine("===== BGE-M3 ONNX Multi-Provider Test =====");
+Console.WriteLine($"Tokenizer: {Path.GetFileName(tokenizerPath)}");
+Console.WriteLine($"Model: {Path.GetFileName(modelPath)}");
 
-// Create the embedding generator with all 3 vector types enabled
-using var embeddingGenerator = new M3Embedder(tokenizerPath, modelPath);
+// Test CPU provider
+Console.WriteLine("\n===== CPU PROVIDER =====");
+TestProvider("CPU", () => M3EmbedderFactory.CreateCpuOptimized(tokenizerPath, modelPath), text);
 
-var embeddings = embeddingGenerator.GenerateEmbeddings(text);
-
-// Print dense embedding information
-Console.WriteLine("\n=== DENSE EMBEDDING ===");
-var denseEmbedding = embeddings.DenseEmbedding;
-Console.WriteLine($"Length: {denseEmbedding.Length}");
-Console.WriteLine($"First 10 values: [{string.Join(", ", denseEmbedding.Take(10).Select(v => v.ToString("F6", CultureInfo.InvariantCulture)))}]");
-
-// Print sparse weights information
-Console.WriteLine("\n=== SPARSE WEIGHTS ===");
-var sparseWeights = embeddings.SparseWeights;
-
-Console.WriteLine($"Non-zero tokens: {sparseWeights.Count}");
-
-// Top tokens
-var topWeights = sparseWeights
-    .OrderByDescending(kv => kv.Value)
-    .Take(5)
-    .ToList();
-
-Console.WriteLine("Top 5 tokens:");
-foreach (var (tokenId, weight) in topWeights)
+// Test CUDA provider
+Console.WriteLine("\n===== CUDA PROVIDER =====");
+try
 {
-    Console.WriteLine($"  {tokenId}: {weight:F6}");
+    TestProvider("CUDA", () => M3EmbedderFactory.CreateCudaOptimized(tokenizerPath, modelPath), text);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"✗ CUDA not available: {ex.Message}");
 }
 
-// Print ColBERT vectors information
-Console.WriteLine("\n=== COLBERT VECTORS ===");
-var colbertVectors = embeddings.ColBertVectors;
+Console.WriteLine("\n===== TEST COMPLETE =====");
 
-Console.WriteLine($"Token count: {colbertVectors.Length}");
-Console.WriteLine($"Vector dimension: {colbertVectors[0].Length}");
+static void TestProvider(string providerName, Func<M3Embedder> embedderFactory, string testText)
+{
+    using var embedder = embedderFactory();
 
-// Print first vector
-Console.WriteLine("First vector (first 10 values):");
-Console.WriteLine($"[{string.Join(", ", colbertVectors[0].Take(10).Select(v => v.ToString("F6", CultureInfo.InvariantCulture)))}]");
+    Console.WriteLine($"Provider: {embedder.Config.ExecutionProvider}");
 
-Console.WriteLine("\n===== SUCCESS =====");
-Console.WriteLine("All embedding types generated successfully!");
+    // Generate embeddings
+    var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+    var embeddings = embedder.GenerateEmbeddings(testText);
+    stopwatch.Stop();
+
+    Console.WriteLine($"Inference time: {stopwatch.ElapsedMilliseconds}ms");
+
+    // Print dense embedding information
+    Console.WriteLine("\n=== DENSE EMBEDDING ===");
+    var denseEmbedding = embeddings.DenseEmbedding;
+    Console.WriteLine($"Length: {denseEmbedding.Length}");
+    Console.WriteLine($"First 10 values: [{string.Join(", ", denseEmbedding.Take(10).Select(v => v.ToString("F6", CultureInfo.InvariantCulture)))}]");
+
+    // Print sparse weights information
+    Console.WriteLine("\n=== SPARSE WEIGHTS ===");
+    var sparseWeights = embeddings.SparseWeights;
+    Console.WriteLine($"Non-zero tokens: {sparseWeights.Count}");
+
+    // Top tokens
+    var topWeights = sparseWeights
+        .OrderByDescending(kv => kv.Value)
+        .Take(5)
+        .ToList();
+
+    Console.WriteLine("Top 5 tokens:");
+    foreach (var (tokenId, weight) in topWeights)
+    {
+        Console.WriteLine($"  {tokenId}: {weight:F6}");
+    }
+
+    // Print ColBERT vectors information
+    Console.WriteLine("\n=== COLBERT VECTORS ===");
+    var colbertVectors = embeddings.ColBertVectors;
+    Console.WriteLine($"Token count: {colbertVectors.Length}");
+    if (colbertVectors.Length > 0)
+    {
+        Console.WriteLine($"Vector dimension: {colbertVectors[0].Length}");
+        Console.WriteLine("First vector (first 10 values):");
+        Console.WriteLine($"[{string.Join(", ", colbertVectors[0].Take(10).Select(v => v.ToString("F6", CultureInfo.InvariantCulture)))}]");
+    }
+
+    Console.WriteLine($"\n✓ {providerName} completed successfully!");
+}


### PR DESCRIPTION
### Multi-Provider Support and Configuration:

* Added a new `ExecutionProvider` enum to define supported providers (CPU and CUDA). (`samples/dotnet/BgeM3.Onnx/ExecutionProvider.cs`)
* Introduced `M3EmbedderConfig`, a configuration class to specify execution provider settings, including primary and fallback providers, CUDA device ID, and optimization flags. (`samples/dotnet/BgeM3.Onnx/M3EmbedderConfig.cs`)
* Updated `M3Embedder` to support multi-provider execution using the new configuration. (`samples/dotnet/BgeM3.Onnx/M3Embedder.cs`)

### Factory and Test Enhancements:

* Added `M3EmbedderFactory`, a factory class for creating `M3Embedder` instances with predefined configurations (e.g., CPU-optimized, CUDA-optimized, or custom). (`samples/dotnet/BgeM3.Onnx/M3EmbedderFactory.cs`)
* Refactored `Program.cs` to test embedding generation using both CPU and CUDA providers, with fallback and error handling for unavailable providers. (`samples/dotnet/BgeM3.Onnx/Program.cs`) [[1]](diffhunk://#diff-9fcd894002c305ef099cfd36f6d22ab02f479855eb5d3fe8e62828f7a0fb24f0L14-R46) [[2]](diffhunk://#diff-9fcd894002c305ef099cfd36f6d22ab02f479855eb5d3fe8e62828f7a0fb24f0L32) [[3]](diffhunk://#diff-9fcd894002c305ef099cfd36f6d22ab02f479855eb5d3fe8e62828f7a0fb24f0L50-R83)