### PR TITLE
Add CUDA Support For Java Sample

### DIFF
--- a/samples/java/bge-m3-onnx/pom.xml
+++ b/samples/java/bge-m3-onnx/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>com.microsoft.onnxruntime</groupId>
-      <artifactId>onnxruntime</artifactId>
+      <artifactId>onnxruntime_gpu</artifactId>
       <version>1.22.0</version>
     </dependency>
     <dependency>

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/ExecutionProvider.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/ExecutionProvider.java
@@ -1,0 +1,16 @@
+package com.yunikosoftware.bgem3onnx;
+
+/**
+ * Supported execution providers for ONNX inference
+ */
+public enum ExecutionProvider {
+    /**
+     * CPU execution provider (default, always available)
+     */
+    CPU,
+
+    /**
+     * CUDA execution provider (requires CUDA-enabled GPU and CUDA runtime)
+     */
+    CUDA
+}

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3Embedder.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3Embedder.java
@@ -77,8 +77,6 @@ public class M3Embedder implements AutoCloseable {
         for (ExecutionProvider provider : providers) {
             switch (provider) {
                 case CUDA:
-                    Map<String, String> cudaOptions = new HashMap<>();
-                    cudaOptions.put("device_id", String.valueOf(config.getCudaDeviceId()));
                     sessionOptions.addCUDA(config.getCudaDeviceId());
                     break;
 

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderConfig.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderConfig.java
@@ -1,0 +1,96 @@
+package com.yunikosoftware.bgem3onnx;
+
+/**
+ * Configuration for M3Embedder initialization
+ */
+public class M3EmbedderConfig {
+    private final ExecutionProvider executionProvider;
+    private final ExecutionProvider[] fallbackProviders;
+    private final int cudaDeviceId;
+    private final boolean enableMemoryPattern;
+    private final boolean enableCpuMemArena;
+    private final int logSeverityLevel;
+
+    public M3EmbedderConfig() {
+        this(ExecutionProvider.CPU, new ExecutionProvider[]{ExecutionProvider.CPU}, 0, true, true, 2);
+    }
+
+    public M3EmbedderConfig(ExecutionProvider executionProvider, ExecutionProvider[] fallbackProviders, 
+                           int cudaDeviceId, boolean enableMemoryPattern, boolean enableCpuMemArena, 
+                           int logSeverityLevel) {
+        this.executionProvider = executionProvider;
+        this.fallbackProviders = fallbackProviders;
+        this.cudaDeviceId = cudaDeviceId;
+        this.enableMemoryPattern = enableMemoryPattern;
+        this.enableCpuMemArena = enableCpuMemArena;
+        this.logSeverityLevel = logSeverityLevel;
+    }
+
+    public ExecutionProvider getExecutionProvider() {
+        return executionProvider;
+    }
+
+    public ExecutionProvider[] getFallbackProviders() {
+        return fallbackProviders;
+    }
+
+    public int getCudaDeviceId() {
+        return cudaDeviceId;
+    }
+
+    public boolean isEnableMemoryPattern() {
+        return enableMemoryPattern;
+    }
+
+    public boolean isEnableCpuMemArena() {
+        return enableCpuMemArena;
+    }
+
+    public int getLogSeverityLevel() {
+        return logSeverityLevel;
+    }
+
+    public static class Builder {
+        private ExecutionProvider executionProvider = ExecutionProvider.CPU;
+        private ExecutionProvider[] fallbackProviders = new ExecutionProvider[]{ExecutionProvider.CPU};
+        private int cudaDeviceId = 0;
+        private boolean enableMemoryPattern = true;
+        private boolean enableCpuMemArena = true;
+        private int logSeverityLevel = 2;
+
+        public Builder executionProvider(ExecutionProvider executionProvider) {
+            this.executionProvider = executionProvider;
+            return this;
+        }
+
+        public Builder fallbackProviders(ExecutionProvider... fallbackProviders) {
+            this.fallbackProviders = fallbackProviders;
+            return this;
+        }
+
+        public Builder cudaDeviceId(int cudaDeviceId) {
+            this.cudaDeviceId = cudaDeviceId;
+            return this;
+        }
+
+        public Builder enableMemoryPattern(boolean enableMemoryPattern) {
+            this.enableMemoryPattern = enableMemoryPattern;
+            return this;
+        }
+
+        public Builder enableCpuMemArena(boolean enableCpuMemArena) {
+            this.enableCpuMemArena = enableCpuMemArena;
+            return this;
+        }
+
+        public Builder logSeverityLevel(int logSeverityLevel) {
+            this.logSeverityLevel = logSeverityLevel;
+            return this;
+        }
+
+        public M3EmbedderConfig build() {
+            return new M3EmbedderConfig(executionProvider, fallbackProviders, cudaDeviceId, 
+                                      enableMemoryPattern, enableCpuMemArena, logSeverityLevel);
+        }
+    }
+}

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderFactory.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderFactory.java
@@ -1,0 +1,89 @@
+package com.yunikosoftware.bgem3onnx;
+
+import ai.onnxruntime.OrtException;
+
+/**
+ * Factory class for creating M3Embedder instances with common configurations
+ */
+public class M3EmbedderFactory {
+    
+    /**
+     * Creates an M3Embedder optimized for CPU inference
+     * 
+     * @param tokenizerPath Path to the ONNX tokenizer model
+     * @param modelPath Path to the ONNX embedding model
+     * @return M3Embedder configured for CPU
+     * @throws OrtException If there's an error initializing the ONNX sessions
+     */
+    public static M3Embedder createCpuOptimized(String tokenizerPath, String modelPath) throws OrtException {
+        M3EmbedderConfig config = new M3EmbedderConfig.Builder()
+                .executionProvider(ExecutionProvider.CPU)
+                .enableMemoryPattern(true)
+                .enableCpuMemArena(true)
+                .logSeverityLevel(2)
+                .build();
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+
+    /**
+     * Creates an M3Embedder optimized for CUDA inference
+     * 
+     * @param tokenizerPath Path to the ONNX tokenizer model
+     * @param modelPath Path to the ONNX embedding model
+     * @param deviceId CUDA device ID (default: 0)
+     * @return M3Embedder configured for CUDA
+     * @throws OrtException If there's an error initializing the ONNX sessions
+     */
+    public static M3Embedder createCudaOptimized(String tokenizerPath, String modelPath, int deviceId) throws OrtException {
+        M3EmbedderConfig config = new M3EmbedderConfig.Builder()
+                .executionProvider(ExecutionProvider.CUDA)
+                .fallbackProviders(ExecutionProvider.CPU)
+                .cudaDeviceId(deviceId)
+                .enableMemoryPattern(true)
+                .enableCpuMemArena(false) // Disable CPU memory arena when using GPU
+                .logSeverityLevel(2)
+                .build();
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+
+    /**
+     * Creates an M3Embedder optimized for CUDA inference with default device ID (0)
+     * 
+     * @param tokenizerPath Path to the ONNX tokenizer model
+     * @param modelPath Path to the ONNX embedding model
+     * @return M3Embedder configured for CUDA
+     * @throws OrtException If there's an error initializing the ONNX sessions
+     */
+    public static M3Embedder createCudaOptimized(String tokenizerPath, String modelPath) throws OrtException {
+        return createCudaOptimized(tokenizerPath, modelPath, 0);
+    }
+
+    /**
+     * Creates an M3Embedder with custom configuration
+     * 
+     * @param tokenizerPath Path to the ONNX tokenizer model
+     * @param modelPath Path to the ONNX embedding model
+     * @param primaryProvider Primary execution provider
+     * @param fallbackProviders Fallback providers in order of preference
+     * @param cudaDeviceId CUDA device ID (used only if CUDA is specified)
+     * @return M3Embedder with custom configuration
+     * @throws OrtException If there's an error initializing the ONNX sessions
+     */
+    public static M3Embedder createCustom(String tokenizerPath, String modelPath, 
+                                         ExecutionProvider primaryProvider, 
+                                         ExecutionProvider[] fallbackProviders, 
+                                         int cudaDeviceId) throws OrtException {
+        M3EmbedderConfig config = new M3EmbedderConfig.Builder()
+                .executionProvider(primaryProvider)
+                .fallbackProviders(fallbackProviders != null ? fallbackProviders : new ExecutionProvider[]{ExecutionProvider.CPU})
+                .cudaDeviceId(cudaDeviceId)
+                .enableMemoryPattern(true)
+                .enableCpuMemArena(primaryProvider == ExecutionProvider.CPU)
+                .logSeverityLevel(2)
+                .build();
+
+        return new M3Embedder(tokenizerPath, modelPath, config);
+    }
+}


### PR DESCRIPTION
### Multi-provider support enhancements:

* [`samples/java/bge-m3-onnx/pom.xml`](diffhunk://#diff-adaca03987fde5df78780951adb20140d1fcfae2714893511531860cf17e584cL38-R38): Updated dependency to `onnxruntime_gpu` to enable GPU support.
* [`samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3Embedder.java`](diffhunk://#diff-41112ae6948ab5ca3953f661c9219e3a2551f15de4c3928a9dcc5b51cb5073e2L8-R116): Refactored `M3Embedder` to support configurable execution providers using the newly added `M3EmbedderConfig`. Added logic to initialize ONNX sessions based on provider configurations.
* [`samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderConfig.java`](diffhunk://#diff-40a63bc023f828899ab53f7cf540de21a438395f7e44de69638d623e4880056cR1-R96): Introduced `M3EmbedderConfig` for managing execution provider settings, fallback providers, memory optimizations, and logging levels. Includes a builder for flexible configuration.
* [`samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/M3EmbedderFactory.java`](diffhunk://#diff-a924df1d463084ca652f92d52f130f1945221a5a4370b5fc6c656e1386a3a2b0R1-R89): Added factory methods to create `M3Embedder` instances optimized for CPU, CUDA, or custom configurations. Simplifies embedder initialization for different scenarios.
* [`samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/ExecutionProvider.java`](diffhunk://#diff-87432015032a282dcfd658ec8a9e3a2fa2d49529efcfbc0bf6350bf310ae9c8eR1-R16): Defined an enum for supported execution providers (`CPU` and `CUDA`).

### Application updates:

* [`samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/App.java`](diffhunk://#diff-0af9bd2f13a26c0229c6ec858ee760cbdce3af380c118013990c8d25150d71c2R8): Modified the main application to test embedding generation using both CPU and CUDA providers. Added a helper method `testProvider` for provider-specific testing. Updated logging to reflect provider details. [[1]](diffhunk://#diff-0af9bd2f13a26c0229c6ec858ee760cbdce3af380c118013990c8d25150d71c2R8) [[2]](diffhunk://#diff-0af9bd2f13a26c0229c6ec858ee760cbdce3af380c118013990c8d25150d71c2L24-R71) [[3]](diffhunk://#diff-0af9bd2f13a26c0229c6ec858ee760cbdce3af380c118013990c8d25150d71c2L74-R118)

### Testing enhancements:

* [`samples/java/bge-m3-onnx/src/test/java/com/yunikosoftware/bgem3onnx/BgeM3EmbeddingComparisonTests.java`](diffhunk://#diff-e4f4c408f3d39a91caa15349fc506a095831a33cdf39c44a00d08bcdbae472adR4): Updated tests to validate embeddings generated using both CPU and CUDA providers. Added logic to skip CUDA tests if the provider is unavailable. Refactored setup to dynamically check CUDA availability. [[1]](diffhunk://#diff-e4f4c408f3d39a91caa15349fc506a095831a33cdf39c44a00d08bcdbae472adR4) [[2]](diffhunk://#diff-e4f4c408f3d39a91caa15349fc506a095831a33cdf39c44a00d08bcdbae472adL15-R22) [[3]](diffhunk://#diff-e4f4c408f3d39a91caa15349fc506a095831a33cdf39c44a00d08bcdbae472adL30-R68) [[4]](diffhunk://#diff-e4f4c408f3d39a91caa15349fc506a095831a33cdf39c44a00d08bcdbae472adL60-R98)