### PR TITLE
Refactor repository path resolving logic

### DIFF
--- a/samples/dotnet/BgeM3.Onnx.Performance/Program.cs
+++ b/samples/dotnet/BgeM3.Onnx.Performance/Program.cs
@@ -205,21 +205,9 @@ public class Program
 {
     public static async Task<int> Main()
     {
-        // Find repository root and paths
-        var currentDir = Directory.GetCurrentDirectory();
-        var repoRoot = FindRepositoryRoot(currentDir);
-
-        if (repoRoot == null)
-        {
-            Console.WriteLine("ERROR: Could not locate repository root");
-            return 1;
-        }
-
-        var performanceDataDir = Path.Combine(repoRoot, "samples", "performance_data");
-        var onnxDir = Path.Combine(repoRoot, "onnx");
-
-        var tokenizerPath = Path.Combine(onnxDir, "bge_m3_tokenizer.onnx");
-        var modelPath = Path.Combine(onnxDir, "bge_m3_model.onnx");
+        var performanceDataDir = RepositoryUtils.GetPerformanceDataDirectory();
+        var tokenizerPath = RepositoryUtils.GetTokenizerPath();
+        var modelPath = RepositoryUtils.GetModelPath();
 
         Console.WriteLine("=" + new string('=', 59));
         Console.WriteLine("BGE-M3 C# Performance Benchmark");
@@ -351,8 +339,7 @@ public class Program
         }
 
         // Save results
-        Directory.CreateDirectory(onnxDir);
-        var outputPath = Path.Combine(onnxDir, "performance_dotnet.json");
+        var outputPath = Path.Combine(RepositoryUtils.GetOnnxDirectory(), "performance_dotnet.json");
 
         var jsonOptions = new JsonSerializerOptions
         {
@@ -407,27 +394,5 @@ public class Program
         var dataset = JsonSerializer.Deserialize<List<TestText>>(jsonString) ?? throw new InvalidOperationException("Failed to deserialize test dataset");
 
         return dataset;
-    }
-
-    private static string? FindRepositoryRoot(string startPath)
-    {
-        var currentDir = new DirectoryInfo(startPath);
-
-        for (int i = 0; i < 10; i++)
-        {
-            var onnxDir = Path.Combine(currentDir.FullName, "onnx");
-
-            if (Directory.Exists(onnxDir))
-            {
-                return currentDir.FullName;
-            }
-
-            if (currentDir.Parent == null)
-                break;
-
-            currentDir = currentDir.Parent;
-        }
-
-        return null;
     }
 }

--- a/samples/dotnet/BgeM3.Onnx.Tests/BgeM3EmbeddingComparisonTests.cs
+++ b/samples/dotnet/BgeM3.Onnx.Tests/BgeM3EmbeddingComparisonTests.cs
@@ -22,12 +22,9 @@ public sealed class BgeM3EmbeddingComparisonTests : IDisposable
 
     public BgeM3EmbeddingComparisonTests()
     {
-        var repoDir = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..", ".."));
-        var onnxDir = Path.Combine(repoDir, "onnx");
-
-        var tokenizerPath = Path.Combine(onnxDir, "bge_m3_tokenizer.onnx");
-        var modelPath = Path.Combine(onnxDir, "bge_m3_model.onnx");
-        var referenceFile = Path.Combine(onnxDir, "bge_m3_reference_embeddings.json");
+        var tokenizerPath = RepositoryUtils.GetTokenizerPath();
+        var modelPath = RepositoryUtils.GetModelPath();
+        var referenceFile = Path.Combine(RepositoryUtils.GetOnnxDirectory(), "bge_m3_reference_embeddings.json");
 
         if (!File.Exists(tokenizerPath))
         {

--- a/samples/dotnet/BgeM3.Onnx/Program.cs
+++ b/samples/dotnet/BgeM3.Onnx/Program.cs
@@ -1,12 +1,8 @@
 ﻿using BgeM3.Onnx;
 using System.Globalization;
 
-// Define paths relative to the project
-var repoDir = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..", "..", ".."));
-var onnxDir = Path.Combine(repoDir, "onnx");
-
-var tokenizerPath = Path.Combine(onnxDir, "bge_m3_tokenizer.onnx");
-var modelPath = Path.Combine(onnxDir, "bge_m3_model.onnx");
+var tokenizerPath = RepositoryUtils.GetTokenizerPath();
+var modelPath = RepositoryUtils.GetModelPath();
 
 // Sample text to test with
 string text = "A test text! Texto de prueba! Текст для теста! 測試文字! Testtext! Testez le texte! Сынақ мәтіні! Тестни текст! परीक्षण पाठ! Kiểm tra văn bản!";

--- a/samples/dotnet/BgeM3.Onnx/RepositoryUtils.cs
+++ b/samples/dotnet/BgeM3.Onnx/RepositoryUtils.cs
@@ -1,0 +1,57 @@
+﻿namespace BgeM3.Onnx;
+
+/// <summary>
+/// Utility class for repository path operations
+/// </summary>
+public static class RepositoryUtils
+{
+    /// <summary>
+    /// Gets the path to the onnx directory
+    /// </summary>
+    /// <returns>The absolute path to the onnx directory</returns>
+    public static string GetOnnxDirectory() => Path.Combine(FindRepositoryRoot(), "onnx");
+
+    /// <summary>
+    /// Gets the path to the BGE-M3 tokenizer ONNX file
+    /// </summary>
+    /// <returns>The absolute path to the tokenizer file</returns>
+    public static string GetTokenizerPath() => Path.Combine(GetOnnxDirectory(), "bge_m3_tokenizer.onnx");
+
+    /// <summary>
+    /// Gets the path to the BGE-M3 model ONNX file
+    /// </summary>
+    /// <returns>The absolute path to the model file</returns>
+    public static string GetModelPath() => Path.Combine(GetOnnxDirectory(), "bge_m3_model.onnx");
+
+    /// <summary>
+    /// Gets the path to the performance data directory
+    /// </summary>
+    /// <returns>The absolute path to the performance data directory</returns>
+    public static string GetPerformanceDataDirectory() => Path.Combine(FindRepositoryRoot(), "samples", "performance_data");
+
+    /// <summary>
+    /// Finds the repository root by looking for the 'onnx' directory
+    /// </summary>
+    /// <returns>The absolute path to the repository root</returns>
+    /// <exception cref="DirectoryNotFoundException">Thrown when repository root cannot be found</exception>
+    private static string FindRepositoryRoot()
+    {
+        var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+        for (int i = 0; i < 10; i++)
+        {
+            var onnxDir = Path.Combine(currentDir.FullName, "onnx");
+            if (Directory.Exists(onnxDir))
+            {
+                return currentDir.FullName;
+            }
+
+            if (currentDir.Parent == null)
+                break;
+
+            currentDir = currentDir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root with 'onnx' directory");
+    }
+}

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/App.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/App.java
@@ -1,8 +1,5 @@
 package com.yunikosoftware.bgem3onnx;
 
-import java.io.FileNotFoundException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Map;
 
@@ -14,12 +11,9 @@ public class App {
 
     public static void main(String[] args) {
         try {
-            // Define paths relative to the project
-            Path repoDir = findRepositoryRoot();
-            Path onnxDir = repoDir.resolve("onnx");
-
-            Path tokenizerPath = onnxDir.resolve("bge_m3_tokenizer.onnx");
-            Path modelPath = onnxDir.resolve("bge_m3_model.onnx");
+            // Use utility class for paths
+            var tokenizerPath = RepositoryUtils.getTokenizerPath();
+            var modelPath = RepositoryUtils.getModelPath();
 
             // Sample text to test with
             String text = "A test text! Texto de prueba! Текст для теста! 測試文字! Testtext! Testez le texte! Сынақ мәтіні! Тестни текст! परीक्षण पाठ! Kiểm tra văn bản!";
@@ -119,26 +113,6 @@ public class App {
         } catch (Exception e) {
             throw new RuntimeException("Failed to test " + providerName + " provider", e);
         }
-    }
-
-    private static Path findRepositoryRoot() throws FileNotFoundException {
-        Path currentDir = Paths.get("").toAbsolutePath();
-
-        // Search up the directory tree for the repository root
-        for (int i = 0; i < 10; i++) {
-            Path onnxDir = currentDir.resolve("onnx");
-
-            if (onnxDir.toFile().exists() && onnxDir.toFile().isDirectory()) {
-                return currentDir;
-            }
-
-            Path parent = currentDir.getParent();
-            if (parent == null)
-                break;
-            currentDir = parent;
-        }
-
-        throw new FileNotFoundException("Could not locate repository root with 'onnx' directory");
     }
 
     @FunctionalInterface

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/RepositoryUtils.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/RepositoryUtils.java
@@ -1,0 +1,76 @@
+package com.yunikosoftware.bgem3onnx;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utility class for repository path operations
+ */
+public class RepositoryUtils {
+    /**
+     * Gets the path to the onnx directory
+     * 
+     * @return The absolute path to the onnx directory
+     * @throws FileNotFoundException If repository root cannot be found
+     */
+    public static Path getOnnxDirectory() throws FileNotFoundException {
+        return findRepositoryRoot().resolve("onnx");
+    }
+
+    /**
+     * Gets the path to the BGE-M3 tokenizer ONNX file
+     * 
+     * @return The absolute path to the tokenizer file
+     * @throws FileNotFoundException If repository root cannot be found
+     */
+    public static Path getTokenizerPath() throws FileNotFoundException {
+        return getOnnxDirectory().resolve("bge_m3_tokenizer.onnx");
+    }
+
+    /**
+     * Gets the path to the BGE-M3 model ONNX file
+     * 
+     * @return The absolute path to the model file
+     * @throws FileNotFoundException If repository root cannot be found
+     */
+    public static Path getModelPath() throws FileNotFoundException {
+        return getOnnxDirectory().resolve("bge_m3_model.onnx");
+    }
+
+    /**
+     * Gets the path to the performance data directory
+     * 
+     * @return The absolute path to the performance data directory
+     * @throws FileNotFoundException If repository root cannot be found
+     */
+    public static Path getPerformanceDataDirectory() throws FileNotFoundException {
+        return findRepositoryRoot().resolve("samples").resolve("performance_data");
+    }
+
+    /**
+     * Finds the repository root by looking for the 'onnx' directory
+     * 
+     * @return The absolute path to the repository root
+     * @throws FileNotFoundException If repository root cannot be found
+     */
+    private static Path findRepositoryRoot() throws FileNotFoundException {
+        Path currentDir = Paths.get("").toAbsolutePath();
+
+        for (int i = 0; i < 10; i++) {
+            Path onnxDir = currentDir.resolve("onnx");
+
+            if (onnxDir.toFile().exists() && onnxDir.toFile().isDirectory()) {
+                return currentDir;
+            }
+
+            Path parent = currentDir.getParent();
+            if (parent == null) {
+                break;
+            }
+            currentDir = parent;
+        }
+
+        throw new FileNotFoundException("Could not locate repository root with 'onnx' directory");
+    }
+}

--- a/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/performance/PerformanceMain.java
+++ b/samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/performance/PerformanceMain.java
@@ -3,11 +3,11 @@ package com.yunikosoftware.bgem3onnx.performance;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.yunikosoftware.bgem3onnx.RepositoryUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -21,12 +21,10 @@ public class PerformanceMain {
     public static void main(String[] args) {
         try {
             // Find repository root and paths
-            Path repoRoot = findRepositoryRoot();
-            Path performanceDataDir = repoRoot.resolve("samples").resolve("performance_data");
-            Path onnxDir = repoRoot.resolve("onnx");
-
-            Path tokenizerPath = onnxDir.resolve("bge_m3_tokenizer.onnx");
-            Path modelPath = onnxDir.resolve("bge_m3_model.onnx");
+            Path performanceDataDir = RepositoryUtils.getPerformanceDataDirectory();
+            Path onnxDir = RepositoryUtils.getOnnxDirectory();
+            Path tokenizerPath = RepositoryUtils.getTokenizerPath();
+            Path modelPath = RepositoryUtils.getModelPath();
 
             System.out.println("=" + "=".repeat(59));
             System.out.println("BGE-M3 Java Performance Benchmark");
@@ -163,28 +161,5 @@ public class PerformanceMain {
 
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.readValue(datasetFile, new TypeReference<List<TestText>>() {});
-    }
-
-    /**
-     * Find repository root by looking for 'onnx' directory
-     */
-    private static Path findRepositoryRoot() throws FileNotFoundException {
-        Path currentDir = Paths.get("").toAbsolutePath();
-
-        for (int i = 0; i < 10; i++) {
-            Path onnxDir = currentDir.resolve("onnx");
-
-            if (onnxDir.toFile().exists() && onnxDir.toFile().isDirectory()) {
-                return currentDir;
-            }
-
-            Path parent = currentDir.getParent();
-            if (parent == null) {
-                break;
-            }
-            currentDir = parent;
-        }
-
-        throw new FileNotFoundException("Could not locate repository root with 'onnx' directory");
     }
 }

--- a/samples/java/bge-m3-onnx/src/test/java/com/yunikosoftware/bgem3onnx/BgeM3EmbeddingComparisonTests.java
+++ b/samples/java/bge-m3-onnx/src/test/java/com/yunikosoftware/bgem3onnx/BgeM3EmbeddingComparisonTests.java
@@ -40,12 +40,9 @@ public class BgeM3EmbeddingComparisonTests {
 
     @BeforeAll
     public static void setupClass() throws Exception {
-        Path repoDir = findRepositoryRoot();
-        Path onnxDir = repoDir.resolve("onnx");
-
-        Path tokenizerFile = onnxDir.resolve("bge_m3_tokenizer.onnx");
-        Path modelFile = onnxDir.resolve("bge_m3_model.onnx");
-        Path referenceFile = onnxDir.resolve("bge_m3_reference_embeddings.json");
+        Path tokenizerFile = RepositoryUtils.getTokenizerPath();
+        Path modelFile = RepositoryUtils.getModelPath();
+        Path referenceFile = RepositoryUtils.getOnnxDirectory().resolve("bge_m3_reference_embeddings.json");
 
         if (!tokenizerFile.toFile().exists())
             throw new FileNotFoundException("Tokenizer file not found at " + tokenizerFile);
@@ -204,25 +201,5 @@ public class BgeM3EmbeddingComparisonTests {
             cudaEmbedder.close();
             cudaEmbedder = null;
         }
-    }
-
-    private static Path findRepositoryRoot() throws FileNotFoundException {
-        Path currentDir = Paths.get("").toAbsolutePath();
-
-        // Search up the directory tree for the repository root
-        for (int i = 0; i < 10; i++) {
-            Path onnxDir = currentDir.resolve("onnx");
-
-            if (onnxDir.toFile().exists() && onnxDir.toFile().isDirectory()) {
-                return currentDir;
-            }
-
-            Path parent = currentDir.getParent();
-            if (parent == null)
-                break;
-            currentDir = parent;
-        }
-
-        throw new FileNotFoundException("Could not locate repository root with 'onnx' directory");
     }
 }


### PR DESCRIPTION
### .NET Codebase Changes:

**Centralized Path Operations:**
- Added `RepositoryUtils` class in `samples/dotnet/BgeM3.Onnx/RepositoryUtils.cs` to provide reusable methods for accessing paths such as the ONNX directory, tokenizer file, model file, and performance data directory.
- Updated `samples/dotnet/BgeM3.Onnx.Performance/Program.cs` to use `RepositoryUtils` for path operations, replacing inline logic for path construction. [[1]](diffhunk://#diff-e73853df48d95048e2c7955b4637c7caba6698f6d4afd11c5650ed376b5e8337L208-R210) [[2]](diffhunk://#diff-e73853df48d95048e2c7955b4637c7caba6698f6d4afd11c5650ed376b5e8337L354-R342)
- Removed the `FindRepositoryRoot` method from `Program.cs` as its functionality is now encapsulated in `RepositoryUtils`.

**Test Code Updates:**
- Modified `samples/dotnet/BgeM3.Onnx.Tests/BgeM3EmbeddingComparisonTests.cs` to use `RepositoryUtils` for path-related operations in test setup, ensuring consistency with the main application logic.

### Java Codebase Changes:

**Centralized Path Operations:**
- Added `RepositoryUtils` class in `samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/RepositoryUtils.java` to provide reusable methods for accessing paths similar to the .NET implementation.
- Updated `samples/java/bge-m3-onnx/src/main/java/com/yunikosoftware/bgem3onnx/App.java` and `PerformanceMain.java` to use `RepositoryUtils` for path operations, replacing inline logic for path construction. [[1]](diffhunk://#diff-0af9bd2f13a26c0229c6ec858ee760cbdce3af380c118013990c8d25150d71c2L17-R16) [[2]](diffhunk://#diff-daf546a8bed99e188451480fa177e2e70ec81aa4b010f9248d5acf7402bd3af1L24-R27)

**Test Code Updates:**
- Modified `samples/java/bge-m3-onnx/src/test/java/com/yunikosoftware/bgem3onnx/BgeM3EmbeddingComparisonTests.java` to use `RepositoryUtils` for path-related operations in test setup, similar to the .NET test changes.