### PR TITLE
Add CUDA benchmarking for FlagEmbedding

### DIFF
--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -47,7 +47,7 @@ try {
 }
 
 # Check if required packages are installed
-$packages = @("onnx", "onnxruntime", "onnxruntime_extensions", "numpy", "pytest", "transformers", "FlagEmbedding")
+$packages = @("onnx", "onnxruntime", "onnxruntime_extensions", "numpy", "pytest", "transformers", "FlagEmbedding", "torch")
 $missingPackages = @()
 
 foreach ($pkg in $packages) {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,7 +37,7 @@ fi
 echo "Found Python: $(python3 --version)"
 
 # Check if required packages are installed
-PACKAGES=("onnx" "onnxruntime" "onnxruntime-extensions" "numpy" "pytest" "transformers" "FlagEmbedding")
+PACKAGES=("onnx" "onnxruntime" "onnxruntime-extensions" "numpy" "pytest" "transformers" "FlagEmbedding", "torch")
 MISSING_PACKAGES=()
 
 for pkg in "${PACKAGES[@]}"; do

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,7 +37,7 @@ fi
 echo "Found Python: $(python3 --version)"
 
 # Check if required packages are installed
-PACKAGES=("onnx" "onnxruntime" "onnxruntime-extensions" "numpy" "pytest" "transformers" "FlagEmbedding", "torch")
+PACKAGES=("onnx" "onnxruntime" "onnxruntime-extensions" "numpy" "pytest" "transformers" "FlagEmbedding" "torch")
 MISSING_PACKAGES=()
 
 for pkg in "${PACKAGES[@]}"; do

--- a/samples/python/bge_m3_tests.py
+++ b/samples/python/bge_m3_tests.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import os
+import torch
 from typing import Dict, List
 from bge_m3_embedder import create_cpu_embedder, create_cuda_embedder
 from transformers import AutoTokenizer


### PR DESCRIPTION
**Performance benchmarking enhancements:**

* Added a new `benchmark_flagembedding_cuda` method to `performance_test.py` to benchmark FlagEmbedding BGE-M3 on CUDA, including device checks, initialization, and error handling. The results now include device information for both CPU and CUDA runs. [[1]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L4-R11) [[2]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L92-R101) [[3]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9R117-R158) [[4]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9R245-R248) [[5]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L231-R310)
* Updated the main benchmarking workflow to run both CPU and CUDA benchmarks for FlagEmbedding, and improved how errors and device availability are reported in the results. [[1]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L231-R310) [[2]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L260-R321)

**Dependency management:**

* Added `torch` to the list of required packages in both `run_tests.ps1` and `run_tests.sh` to ensure all dependencies are checked before running tests. [[1]](diffhunk://#diff-401cc55338428c707556e5aaae05603d01ad7850fef6c59fe3ada84b60181acbL50-R50) [[2]](diffhunk://#diff-852f71b2f559b6a22ca607e43dc0c380f77224a2bb4341644f6bfda23e30f7e4L40-R40)
* Imported `torch` in `bge_m3_tests.py` and `performance_test.py` to support CUDA device checks and benchmarking. [[1]](diffhunk://#diff-198dad29d5eb66458a042b8b8bef794326b937ca2e8d39d895551b3516a04da3R4) [[2]](diffhunk://#diff-d39d4ee1b906a399cf48998bda4fb13aa97620e09173466253829748662ddaa9L4-R11)

**Other improvements:**

* Improved device and CUDA status reporting at the start of the performance test, including device count and name when available.
* Clarified error messages and fixed a typo in error reporting for ONNX CUDA benchmarking.