### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+# Java Maven dependencies
+- package-ecosystem: "maven"
+  directory: "/samples/java/bge-m3-onnx"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+
+# .NET NuGet dependencies for main project
+- package-ecosystem: "nuget"
+  directory: "/samples/dotnet/BgeM3.Onnx"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+
+# .NET NuGet dependencies for test project
+- package-ecosystem: "nuget"
+  directory: "/samples/dotnet/BgeM3.Onnx.Tests"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+
+# .NET NuGet dependencies for performance project
+- package-ecosystem: "nuget"
+  directory: "/samples/dotnet/BgeM3.Onnx.Performance"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+
+# GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 3


### PR DESCRIPTION
This pull request adds a new `.github/dependabot.yml` configuration file to enable automated dependency updates for several parts of the project. Dependabot will now regularly check for updates to Java Maven, .NET NuGet, and GitHub Actions dependencies and open pull requests as needed.

Dependency update automation:

* Added `.github/dependabot.yml` to configure Dependabot for automated updates of:
  * Java Maven dependencies in `samples/java/bge-m3-onnx`
  * .NET NuGet dependencies in `samples/dotnet/BgeM3.Onnx`, `samples/dotnet/BgeM3.Onnx.Tests`, and `samples/dotnet/BgeM3.Onnx.Performance`
  * GitHub Actions workflows in the repository root